### PR TITLE
Bugfix for Collection.fetch

### DIFF
--- a/composer.js
+++ b/composer.js
@@ -468,7 +468,7 @@
 			options.success	=	function(res)
 			{
 				this.set(this.parse(res), options);
-				if(success) success(model, res);
+				if(success) success(this, res);
 			}.bind(this);
 			options.error	=	wrap_error(options.error ? options.error.bind(this) : null, this, options).bind(this);
 			return (this.sync || Composer.sync).call(this, 'read', this, options);
@@ -510,7 +510,7 @@
 			options.success	=	function(res)
 			{
 				this.fire_event('destroy', options, this, this.collections, options);
-				if(success) success(model, res);
+				if(success) success(this, res);
 			}.bind(this);
 			options.error	=	wrap_error(options.error ? options.error.bind(this) : null, this, options).bind(this);
 			return (this.sync || Composer.sync).call(this, 'delete', this, options);
@@ -1043,7 +1043,7 @@
 			options.success	=	function(res)
 			{
 				this.reset(this.parse(res), options);
-				if(success) success(this.model, res);
+				if(success) success(this, res);
 			}.bind(this);
 			options.error	=	wrap_error(options.error ? options.error.bind(this) : null, this, options).bind(this);
 			return (this.sync || Composer.sync).call(this, 'read', this, options);


### PR DESCRIPTION
Hi folks,

the scope of the variable 'model' is wrong - it results in an UncaughtReference error. As the callback is bound to the collection, the variable has to be referenced with "this.model". Works for me!

Reproduce: Fetch a collection successfully from the server and hand a callback for 'success' into the fetch method.

GREAT framework. Backbone sucks, as it relies on jQuery. I love Composer.js!

Best regards,
Martin
