### PR TITLE
Fixed references in success callbacks

### DIFF
--- a/composer.js
+++ b/composer.js
@@ -468,7 +468,7 @@
 			options.success	=	function(res)
 			{
 				this.set(this.parse(res), options);
-				if(success) success(model, res);
+				if(success) success(this, res);
 			}.bind(this);
 			options.error	=	wrap_error(options.error ? options.error.bind(this) : null, this, options).bind(this);
 			return (this.sync || Composer.sync).call(this, 'read', this, options);
@@ -510,7 +510,7 @@
 			options.success	=	function(res)
 			{
 				this.fire_event('destroy', options, this, this.collections, options);
-				if(success) success(model, res);
+				if(success) success(this, res);
 			}.bind(this);
 			options.error	=	wrap_error(options.error ? options.error.bind(this) : null, this, options).bind(this);
 			return (this.sync || Composer.sync).call(this, 'delete', this, options);
@@ -1043,7 +1043,7 @@
 			options.success	=	function(res)
 			{
 				this.reset(this.parse(res), options);
-				if(success) success(this.model, res);
+				if(success) success(this, res);
 			}.bind(this);
 			options.error	=	wrap_error(options.error ? options.error.bind(this) : null, this, options).bind(this);
 			return (this.sync || Composer.sync).call(this, 'read', this, options);


### PR DESCRIPTION
Hi guys,

I revoked my prior pull request, as i reviewed my solution again.

In the model classes' `save` method, the custom success callback (if existent) is called with `this` (the current model) and `res` (the result). I believe that this must also be done in `fetch` (model and collection) and `destroy` (only model). In all three methods, the variable model isn't set within the scope.

What do you think? For me, this solution works as expected.

Best regards,
Martin
