### PR TITLE
Bugfix: last() did not return last element of collection

### DIFF
--- a/composer.js
+++ b/composer.js
@@ -1100,7 +1100,7 @@
 		last: function(n)
 		{
 			var models	=	this.models();
-			return (typeof(n) != 'undefined' && parseInt(n) != 0) ? models.slice(models.length - n) : models[0];
+			return (typeof(n) != 'undefined' && parseInt(n) != 0) ? models.slice(models.length - n) : models[models.length - 1];
 		},
 
 		/**


### PR DESCRIPTION
Hey folks, 

the collection class was returning the first element if no parameter was passed to `Collection.last`. Code attached!

Best,
Martin
