### PR TITLE
Added Collection.map() in order to execute a function on all models and return the results

### DIFF
--- a/composer.js
+++ b/composer.js
@@ -953,6 +953,21 @@
 		},
 
 		/**
+		 * convenience function to execute a function on a collection's models
+		 */
+		map: function(cb, bind)
+		{
+			if(bind)
+			{
+				return this.models().map(cb, bind);
+			}
+			else
+			{
+				return this.models().map(cb);
+			}
+		},
+
+		/**
 		 * Find the first model that satisfies the callback. An optional sort function
 		 * can be passed in to order the results of the find, which uses the usual 
 		 * fn(a,b){return (-1|0|1);} syntax.


### PR DESCRIPTION
Hey folks,

this pull-request is more a suggestions than a bugfix. I had to execute a function on a collections models lately quite often, so I wrote a wrapper for it (exactly like `Collection.each`). So now, instead of the rather ugly way:

```
results = mycollection.models().map(function(item) { ... })
```

... you can now do:

```
results = mycollection.map(function(item) { ... })
```

Hope you like it and it fits the overall context.

All the best,
Martin
