### PR TITLE
Fixed Model's "get" method to to handle 'null' values of a model key

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -97,7 +97,7 @@
 		get: function(key, def)
 		{
 			if(typeof(def) == 'undefined') def = null;
-			if(typeof(this.data[key]) == 'undefined')
+			if(!this.data[key])
 			{
 				return def;
 			}


### PR DESCRIPTION
Fixed Model's "get" method to return passed default param when the value of a key is null. typeof(null) returns "object" and def is not returned in this case.
